### PR TITLE
Complex.html and Experimental.html fixed

### DIFF
--- a/complex.html
+++ b/complex.html
@@ -82,7 +82,7 @@
     </div>
     <canvas id="canvas" width="900px" height="1000px"></canvas>
   </div>
-  <script src="./src/complex.js" type="module"></script>
+  <script src="./src/complex.js"></script>
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
 </body>
 </html>

--- a/experimental.html
+++ b/experimental.html
@@ -90,7 +90,7 @@
     </div>
     <canvas id="canvas" width="1200px" height="1000px"></canvas>
   </div>
-  <script src="./src/main.js" type="module"></script>
+  <script src="./src/main.js"></script>
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
 </body>
 </html>

--- a/src/complex.js
+++ b/src/complex.js
@@ -1,4 +1,64 @@
-import {random} from './random.js';
+//import {random} from './random.js';
+
+// Otherwise, when you view the same L-System with the same parameters,
+// using Math.random(), it'll change each time.
+//
+// Code from https://stackoverflow.com/questions/521295/
+
+const random = (function() {
+
+  function xmur3(str) {
+    for(var i = 0, h = 1779033703 ^ str.length; i < str.length; i++)
+        h = Math.imul(h ^ str.charCodeAt(i), 3432918353),
+        h = h << 13 | h >>> 19;
+    return function() {
+        h = Math.imul(h ^ h >>> 16, 2246822507);
+        h = Math.imul(h ^ h >>> 13, 3266489909);
+        return (h ^= h >>> 16) >>> 0;
+    }
+  }
+
+  function sfc32(a, b, c, d) {
+    return function() {
+      a >>>= 0; b >>>= 0; c >>>= 0; d >>>= 0; 
+      var t = (a + b) | 0;
+      a = b ^ b >>> 9;
+      b = c + (c << 3) | 0;
+      c = (c << 21 | c >>> 11);
+      d = d + 1 | 0;
+      t = t + d | 0;
+      c = c + t | 0;
+      return (t >>> 0) / 4294967296;
+    }
+  }
+
+  let _SeededRandom = null;
+
+  function _Random() {
+    if (!_SeededRandom) {
+      _Seed('abc');
+    }
+
+    return _SeededRandom();
+  }
+
+  function _RandomRange(a, b) {
+    return _Random() * (b - a) + a;
+  }
+
+  function _Seed(s) {
+    const seed = xmur3(s + '');
+    _SeededRandom = sfc32(seed(), seed(), seed(), seed());
+  }
+
+  return {
+    Seed: _Seed,
+    Random: _Random,
+    RandomRange: _RandomRange,
+  }
+})();
+
+
 
 console.log('L-Systems Demo');
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,62 @@
-import {random} from './random.js';
+// import {random} from './random.js';
+// Otherwise, when you view the same L-System with the same parameters,
+// using Math.random(), it'll change each time.
+//
+// Code from https://stackoverflow.com/questions/521295/
+
+const random = (function() {
+
+  function xmur3(str) {
+    for(var i = 0, h = 1779033703 ^ str.length; i < str.length; i++)
+        h = Math.imul(h ^ str.charCodeAt(i), 3432918353),
+        h = h << 13 | h >>> 19;
+    return function() {
+        h = Math.imul(h ^ h >>> 16, 2246822507);
+        h = Math.imul(h ^ h >>> 13, 3266489909);
+        return (h ^= h >>> 16) >>> 0;
+    }
+  }
+
+  function sfc32(a, b, c, d) {
+    return function() {
+      a >>>= 0; b >>>= 0; c >>>= 0; d >>>= 0; 
+      var t = (a + b) | 0;
+      a = b ^ b >>> 9;
+      b = c + (c << 3) | 0;
+      c = (c << 21 | c >>> 11);
+      d = d + 1 | 0;
+      t = t + d | 0;
+      c = c + t | 0;
+      return (t >>> 0) / 4294967296;
+    }
+  }
+
+  let _SeededRandom = null;
+
+  function _Random() {
+    if (!_SeededRandom) {
+      _Seed('abc');
+    }
+
+    return _SeededRandom();
+  }
+
+  function _RandomRange(a, b) {
+    return _Random() * (b - a) + a;
+  }
+
+  function _Seed(s) {
+    const seed = xmur3(s + '');
+    _SeededRandom = sfc32(seed(), seed(), seed(), seed());
+  }
+
+  return {
+    Seed: _Seed,
+    Random: _Random,
+    RandomRange: _RandomRange,
+  }
+})();
+
 
 console.log('L-Systems Demo');
 

--- a/src/simple.js
+++ b/src/simple.js
@@ -11,7 +11,7 @@ const _PRESETS = [
   {
     axiom: 'X',
     rules: [
-      ['F', 'FF'],
+      ['F', 'F-F+'],
       ['X', 'F+[-F-XF-X][+FF][--XF[+X]][++F-X]'],
     ]
   },
@@ -32,7 +32,7 @@ const _PRESETS = [
   {
     axiom: 'F',
     rules: [
-      ['F', 'F > F[+F]F[-F]F'],
+      ['F', 'F[-F+F]+F[-F]-F'],
     ]
   },
 ];


### PR DESCRIPTION
Due to some "some origin" policies in the browser only simple.html worked. The use of the custom random function as a module was a problem in complex.html and experimental.html.
This hack fixes this problem by copying the random.js code directly into complex.js and main.js. This is nice, but it works.